### PR TITLE
Enable static routes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,10 +50,8 @@ jobs:
       - name: ✅ Start the server
         run: ./go-compare-it &
 
-      - name: Curl gut check
-        run: curl -v localhost:8080/healthcheck | jq -r ".service"
-
       - name: 🩺 Ping the healthcheck
+        id: ping-script
         run: | 
           chmod +x .github/workflows/scripts/ping.sh
           sh .github/workflows/scripts/ping.sh

--- a/.github/workflows/scripts/ping.sh
+++ b/.github/workflows/scripts/ping.sh
@@ -9,4 +9,3 @@ else
    echo "The API did not respond to a healthcheck"
    exit 1
 fi
-

--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@ To get started with Go Compare It, follow these steps:
 
 ## This application is…
 
-…written in [Go](https://go.dev/),
-backed by [PostgreSQL](https://www.postgresql.org/),
-powered by [dGraph](https://github.com/dgraph-io/dgraph),
+…written in [Go](https://go.dev/)
+using the [Gin Framework](https://github.com/gin-gonic/gin),
+backed by [PostgreSQL](https://www.postgresql.org/) and
+powered by [dGraph](https://github.com/dgraph-io/dgraph).  It has been
 made sentient by [LLaMA.go
-](https://github.com/gotzmann/llama.go),
-and to a lesser extent [OpenLLaMA](https://github.com/yxuansu/OpenAlpaca)...
+](https://github.com/gotzmann/llama.go)
+(and to a lesser extent [OpenLLaMA](https://github.com/yxuansu/OpenAlpaca))...
 
 ## Graph Database
 Go Compare It&trade; uses a graph database to maintain high dimensional space for relationships

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -3,9 +3,11 @@ package router
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/kmesiab/go-compare-it/internal/controller"
+	"net/http"
 )
 
 const currentVersionPath = "/api/v1/"
+const staticRoute = "/a/1/"
 
 // apiRoutes is the router group based on the root
 // path defined in router.currentVersionPath
@@ -15,8 +17,8 @@ var apiRoutes *gin.RouterGroup
 // gin engine
 func Init(router *gin.Engine) {
 
-	// Infrastructure Routes
 	router.GET("/healthcheck", controller.Healthcheck)
+	router.StaticFS(staticRoute, http.Dir("public"))
 
 	if apiRoutes == nil {
 		apiRoutes = router.Group(currentVersionPath)
@@ -28,6 +30,5 @@ func Init(router *gin.Engine) {
 // InitApiRoutes attaches all API endpoints to the
 // current api's router group
 func InitApiRoutes(router *gin.RouterGroup) {
-	router.POST("/api/v1/users/create", controller.CreateUser)
-
+	router.POST("users", controller.CreateUser)
 }


### PR DESCRIPTION
This pull request adds static routes to the `./public` folder, enabled at `http://localhost:8080/a/1/...` where `/a/1/` are virtual paths. 

Thinking:

This path `/a/1/` has been set up to point to a specific _version_ of static assets. It can be changed to point to a new 'version' of static assets, for example:

 `/a/1`/ -> `./theme1/` 
becomes 
`/a/2`/ -> `./theme2/`.

_It made sense at the time_